### PR TITLE
drop phpstan/phpstan-php-parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
         "ext-json": "*"
     },
     "require-dev": {
-        "phpstan/phpstan": "~1.10.47",
-        "phpstan/phpstan-php-parser": "~1.1"
+        "phpstan/phpstan": "~1.10.47"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
the phpstan/phpstan-php-parser package is obsolete and you should no longer use it in your composer.json/composer.lock

see https://github.com/phpstan/phpstan-php-parser

![grafik](https://github.com/user-attachments/assets/9670d43c-fa92-4965-ba04-67403a47a322)
